### PR TITLE
XCVB support

### DIFF
--- a/build.xcvb
+++ b/build.xcvb
@@ -1,0 +1,1 @@
+#+xcvb (module (:fullname "/trivial-garbage" :depends-on ("trivial-garbage")))

--- a/trivial-garbage.lisp
+++ b/trivial-garbage.lisp
@@ -6,6 +6,8 @@
 ;;; <loliveira@common-lisp.net> and is provided with absolutely no
 ;;; warranty.
 
+#+xcvb (module ())
+
 (defpackage #:trivial-garbage
   (:use #:cl)
   (:shadow #:make-hash-table)


### PR DESCRIPTION
It's trivial to add XCVB support to trivial-garbage.
Can you do it upstream? That way, I don't have to keep maintaining a fork to build it with XCVB.
Thanks!
