### PR TITLE
finalize: ecl: prevent capturing the finalized object in bytecmp

### DIFF
--- a/tests.lisp
+++ b/tests.lisp
@@ -78,15 +78,20 @@
   nil)
 
 (defun test-finalizers-aux (count extra-action)
-  (let ((cons (list 0))
-        (obj (string (gensym))))
+  (let* ((cons (list 0))
+         ;; lbd should not be defined in a lexical scope where obj is
+         ;; present to prevent closing over the variable on compilers
+         ;; which does not optimize away unused lexenv variables (i.e
+         ;; ecl's bytecmp).
+         (lbd (lambda () (incf (car cons))))
+         (obj (string (gensym))))
     (dotimes (i count)
-      (finalize obj (lambda () (incf (car cons)))))
+      (finalize obj lbd))
     (when extra-action
       (cancel-finalization obj)
       (when (eq extra-action :add-again)
         (dotimes (i count)
-          (finalize obj (lambda () (incf (car cons)))))))
+          (finalize obj lbd))))
     (setq obj (gensym))
     (setq obj (dummy obj))
     cons))

--- a/trivial-garbage.lisp
+++ b/trivial-garbage.lisp
@@ -330,7 +330,8 @@
   #+abcl (ext:finalize object function)
   #+ecl (let* ((old-fn (ext:get-finalizer object))
                (new-fn (extend-finalizer-fn old-fn function)))
-          (ext:set-finalizer object new-fn))
+          (ext:set-finalizer object new-fn)
+          object)
   #+allegro
   (progn
     (push (excl:schedule-finalization


### PR DESCRIPTION
ECL's bytecodes compiler doesn't perform any escape analysis and
bytecompiled functions are closed over all variables in their
definition lexical scope. That means in particular that creating a
lambda in finlize function causes the finalize to close over the
finalized object hence preventing its garbage collection. This problem
does not occur in C compiler. Original issue has been reported here:

https://gitlab.com/embeddable-common-lisp/ecl/issues/505