### PR TITLE
Adapt clasp definition for weak hash-tables (only :key and test #'eq) and expected errors

### DIFF
--- a/tests.lisp
+++ b/tests.lisp
@@ -45,7 +45,10 @@
   (pushnew 'hashtables.weak-value.1 rt::*expected-failures*))
 
 #+clasp
-(pushnew 'hashtables.weak-value.1 rt::*expected-failures*)
+(progn
+  (pushnew 'pointers.1 rt::*expected-failures*)
+  (pushnew 'pointers.2 rt::*expected-failures*)
+  (pushnew 'hashtables.weak-value.1 rt::*expected-failures*))
 
 (deftest hashtables.weak-key.1
     (let ((ht (make-weak-hash-table :weakness :key)))

--- a/trivial-garbage.lisp
+++ b/trivial-garbage.lisp
@@ -339,7 +339,7 @@
            object (lambda (obj) (declare (ignore obj)) (funcall function)))
           (gethash object *finalizers*))
     object)
-  #+clasp (gctools:finalize object #'(lambda(a)(declare (ignore a))(funcall function)))
+  #+clasp (gctools:finalize object (lambda (obj) (declare (ignore obj)) (funcall function)))
   #+clisp
   ;; The CLISP code used to be a bit simpler but we had to workaround
   ;; a bug regarding the interaction between GC and weak hashtables.

--- a/trivial-garbage.lisp
+++ b/trivial-garbage.lisp
@@ -191,17 +191,17 @@
     (:value
      #+allegro :weak
      #+(or clisp openmcl sbcl abcl lispworks cmu ecl-weak-hash) :value
-     #-(or allegro clisp openmcl sbcl abcl lispworks cmu ecl-weak-hash clasp)
+     #-(or allegro clisp openmcl sbcl abcl lispworks cmu ecl-weak-hash)
      (weakness-missing weakness errorp))
     (:key-or-value
      #+(or clisp sbcl abcl cmu) :key-or-value
      #+lispworks :either
-     #-(or clisp sbcl abcl lispworks cmu clasp)
+     #-(or clisp sbcl abcl lispworks cmu)
      (weakness-missing weakness errorp))
     (:key-and-value
      #+(or clisp abcl sbcl cmu ecl-weak-hash) :key-and-value
      #+lispworks :both
-     #-(or clisp sbcl abcl lispworks cmu ecl-weak-hash clasp)
+     #-(or clisp sbcl abcl lispworks cmu ecl-weak-hash)
      (weakness-missing weakness errorp))))
 
 (defun make-weak-hash-table (&rest args &key weakness (weakness-matters t)
@@ -231,6 +231,7 @@
             (opt (weakness-keyword-opt weakness weakness-matters)))
         (apply #'cl:make-hash-table
                #+openmcl :test #+openmcl (if (eq opt :key) #'eq test)
+               #+clasp :test #+clasp #'eq
                (if arg
                    (list* arg opt args)
                    args)))
@@ -338,7 +339,7 @@
            object (lambda (obj) (declare (ignore obj)) (funcall function)))
           (gethash object *finalizers*))
     object)
-  #+clasp (gctools:finalize object function)
+  #+clasp (gctools:finalize object #'(lambda(a)(declare (ignore a))(funcall function)))
   #+clisp
   ;; The CLISP code used to be a bit simpler but we had to workaround
   ;; a bug regarding the interaction between GC and weak hashtables.


### PR DESCRIPTION
* clasp only supports weak-hash-tables with weakness :key and test #'eq
* clasp finalizers have a parameter
* clasp does not support weak pointer for immediates
WIth that (and the fix for https://github.com/clasp-developers/clasp/issues/946) i get
```lisp
TG-TESTS> (rtest::do-tests)
Doing 11 pending tests of 11 tests total.
Test POINTERS.1 failed
Form: (WEAK-POINTER-P (MAKE-WEAK-POINTER 42))
Expected value: T
Actual value: #<CORE:SIMPLE-PROGRAM-ERROR>.
Test POINTERS.2 failed
Form: (WEAK-POINTER-VALUE (MAKE-WEAK-POINTER 42))
Expected value: 42
Actual value: #<CORE:SIMPLE-PROGRAM-ERROR>.
 HASHTABLES.WEAK-KEY.1 HASHTABLES.WEAK-KEY.2
Test HASHTABLES.WEAK-VALUE.1 failed
Form: (LET ((HT (MAKE-WEAK-HASH-TABLE :WEAKNESS :VALUE)))
        (VALUES (HASH-TABLE-P HT) (HASH-TABLE-WEAKNESS HT)))
Expected values: T
                 :VALUE
Actual value: #<SIMPLE-ERROR>.
 HASHTABLES.NOT-WEAK.1 FINALIZERS.1 FINALIZERS.2 FINALIZERS.3
 FINALIZERS.4 FINALIZERS.5
3 out of 11 total tests failed: POINTERS.1, POINTERS.2, HASHTABLES.WEAK-VALUE.1.
No unexpected failures.
````