### PR TITLE
Pass `:dont-save t` to `sb-ext:finalize` for SBCL

### DIFF
--- a/trivial-garbage.lisp
+++ b/trivial-garbage.lisp
@@ -356,7 +356,7 @@
    being garbage collected."
   #+genera (declare (ignore object function))
   #+(or cmu scl) (ext:finalize object function)
-  #+sbcl (sb-ext:finalize object function)
+  #+sbcl (sb-ext:finalize object function :dont-save t)
   #+abcl (ext:finalize object function)
   #+ecl (let* ((old-fn (ext:get-finalizer object))
                (new-fn (extend-finalizer-fn old-fn function)))


### PR DESCRIPTION
Hello, I found an issue while deploying an application built using a recent version of SBCL. When running the dumped image, I encountered a warning of a memory fault occurring in the finalizer. 

To address this, I reached out to SBCL developers (for detailed discussion, please refer to [this mailing list](https://sourceforge.net/p/sbcl/mailman/message/45192912/)), and their response indicated that SBCL does not guarantee the timing of finalizer execution, including during the final garbage collection before the image dump. This results in the deferred execution of finalizers until the image restoration, which can lead to memory errors in finalizers since the foreign memory before the dump becomes invalid after image restoration. 

Considering that most libraries directly use `tg:finalize` for foreign memory management, I think it advisable for `trivial-garbage` to pass the `dont-save :t` argument to `sb-ext:finalize` by default, ensuring that finalizers do not execute after image restoration.